### PR TITLE
VAN-358 Remove Project variable defaults

### DIFF
--- a/terraform/dev/terraform.tfvars
+++ b/terraform/dev/terraform.tfvars
@@ -1,8 +1,3 @@
-## Project
-project_id = "cloudcover-sandbox"
-region     = "asia-southeast1"
-zone       = "asia-southeast1-a"
-
 ## Network
 network_name = "microservice-demo"
 


### PR DESCRIPTION
Due to VAN-357, we can't set defaults for variables that need to be over-ridden at
deploy time in the terraform.tfvars file. In this case, that is the project_id,
zone and region. These will need to be provided via cldcvr.yaml.