### PR TITLE
VAN-382 Use GOOGLE_PROJECT instead of project_id

### DIFF
--- a/cldcvr.yaml
+++ b/cldcvr.yaml
@@ -25,7 +25,6 @@ deployments:
       inputs:
         region: asia-southeast1
         zone: asia-southeast1-a
-        project_id: vanguard-test-deploy
         gke_name: msdemo_online_boutique
     applications:
       msdemo:

--- a/terraform/dev/gke.tf
+++ b/terraform/dev/gke.tf
@@ -1,6 +1,6 @@
 module "gke" {
   source     = "terraform-google-modules/kubernetes-engine/google//modules/private-cluster"
-  project_id = var.project_id
+  project_id = var.GOOGLE_PROJECT
 
   name = "${var.gke_name}-${local.random_id}"
 

--- a/terraform/dev/network.tf
+++ b/terraform/dev/network.tf
@@ -1,5 +1,5 @@
 resource "google_compute_network" "network" {
-  project = var.project_id
+  project = var.GOOGLE_PROJECT
 
   name                    = "${var.network_name}-${local.random_id}"
   auto_create_subnetworks = "false"
@@ -7,7 +7,7 @@ resource "google_compute_network" "network" {
 }
 
 resource "google_compute_subnetwork" "gke" {
-  project = var.project_id
+  project = var.GOOGLE_PROJECT
   region  = var.region
 
   name                     = "${var.gke_subnet_name}-${local.random_id}"

--- a/terraform/dev/variables.tf
+++ b/terraform/dev/variables.tf
@@ -1,4 +1,4 @@
-variable "project_id" {
+variable "GOOGLE_PROJECT" {
   description = "Project id"
   type        = string
 }


### PR DESCRIPTION
Leverage the TF var GOOGLE_PROJECT that is being set in the pipeline
instead of expecting var.project_id to be set by the caller.