### PR TITLE
VAN-402 Remove hardcoded region and zone from cldcvr.yaml

### DIFF
--- a/cldcvr.yaml
+++ b/cldcvr.yaml
@@ -23,15 +23,13 @@ deployments:
     environment:
       name: Dev
       inputs:
-        region: asia-southeast1
-        zone: asia-southeast1-a
         gke_name: msdemo_online_boutique
     applications:
       msdemo:
         pipelineInputs:
           git_remote_path: github.com/cldcvr/microservices-demo
           gke_cluster_name: "$$CLUSTER_NAME"
-          gke_cluster_zone: asia-southeast1-a
+          gke_cluster_region: "$$GOOGLE_REGION"
           pipeline_env: '{"CLUSTER_NAME":"${terraform.gke.value.name}"}'
           pipeline_timeout_sec: "4000"
           pipeline_machine_type: "N1_HIGHCPU_32"

--- a/terraform/dev/gke.tf
+++ b/terraform/dev/gke.tf
@@ -4,9 +4,8 @@ module "gke" {
 
   name = "${var.gke_name}-${local.random_id}"
 
-  regional = false
-  region   = var.region
-  zones    = [var.zone]
+  regional = true
+  region   = var.GOOGLE_REGION
 
   network    = google_compute_network.network.name
   subnetwork = google_compute_subnetwork.gke.name
@@ -19,6 +18,8 @@ module "gke" {
 
   enable_private_endpoint = false
   enable_private_nodes    = true
+
+  default_max_pods_per_node = 20
 
   master_ipv4_cidr_block = var.gke_cidr_range_master
 

--- a/terraform/dev/network.tf
+++ b/terraform/dev/network.tf
@@ -8,7 +8,7 @@ resource "google_compute_network" "network" {
 
 resource "google_compute_subnetwork" "gke" {
   project = var.GOOGLE_PROJECT
-  region  = var.region
+  region  = var.GOOGLE_REGION
 
   name                     = "${var.gke_subnet_name}-${local.random_id}"
   network                  = google_compute_network.network.id

--- a/terraform/dev/variables.tf
+++ b/terraform/dev/variables.tf
@@ -3,13 +3,8 @@ variable "GOOGLE_PROJECT" {
   type        = string
 }
 
-variable "region" {
+variable "GOOGLE_REGION" {
   description = "Project region"
-  type        = string
-}
-
-variable "zone" {
-  description = "Project zone"
   type        = string
 }
 


### PR DESCRIPTION
This project will now use the provided var.GOOGLE_REGION TF variable to
select the region. Decided to make the GKE cluster multi-zone so that
zone will not be selected.

The default_max_pods_per_node was reduced from default of 110 to 20
because when the cluster was switched from single zone to regional, it
is using more network resources and exhausting the IP range.